### PR TITLE
Use gnome souces and fix CI

### DIFF
--- a/appdata-screenshot.patch
+++ b/appdata-screenshot.patch
@@ -1,0 +1,13 @@
+diff --git a/data/org.gnome.dspy.appdata.xml.in.in b/data/org.gnome.dspy.appdata.xml.in.in
+index 7c5135b..06180f2 100644
+--- a/data/org.gnome.dspy.appdata.xml.in.in
++++ b/data/org.gnome.dspy.appdata.xml.in.in
+@@ -19,7 +19,7 @@
+   <screenshots>
+     <screenshot type="default">
+       <caption>D-Spy Interface</caption>
+-      <image width="2104" height="1598">https://gitlab.gnome.org/chergert/d-spy/-/raw/master/data/dspy-1.png</image>
++      <image>https://gitlab.gnome.org/GNOME/d-spy/-/raw/main/data/dspy-1.png</image>
+     </screenshot>
+   </screenshots>
+ 

--- a/org.gnome.dspy.json
+++ b/org.gnome.dspy.json
@@ -72,6 +72,10 @@
                         "name": "dspy",
                         "stable-only": false
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata-screenshot.patch"
                 }
             ]
         }

--- a/org.gnome.dspy.json
+++ b/org.gnome.dspy.json
@@ -64,9 +64,9 @@
             "buildsystem": "meson",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/chergert/d-spy.git",
-                    "commit": "85e405da58e39c67afe98785d4b16df26a1322dd"
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/dspy/1.0/dspy-1.0.0.tar.xz",
+                    "sha256": "a5ec69ca1c605a66215e0bb2623127ab2a1e9a70cce7c5fd29eeb5356ba525f5"
                 }
             ]
         }

--- a/org.gnome.dspy.json
+++ b/org.gnome.dspy.json
@@ -66,7 +66,12 @@
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/dspy/1.0/dspy-1.0.0.tar.xz",
-                    "sha256": "a5ec69ca1c605a66215e0bb2623127ab2a1e9a70cce7c5fd29eeb5356ba525f5"
+                    "sha256": "a5ec69ca1c605a66215e0bb2623127ab2a1e9a70cce7c5fd29eeb5356ba525f5",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "dspy",
+                        "stable-only": false
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Also fixes builds by patching the screenshot url. I am submiting the patch upstream right now.

EDIT: Patch at https://gitlab.gnome.org/GNOME/d-spy/-/merge_requests/4